### PR TITLE
Fix support for python 3.9

### DIFF
--- a/taskgroup/runners.py
+++ b/taskgroup/runners.py
@@ -2,6 +2,7 @@
 # Copyright © 2001-2022 Python Software Foundation; All Rights Reserved
 # modified to support working on 3.10, custom task_factory installed to
 # support uncancel and contexts
+from __future__ import annotations
 
 __all__ = ('Runner', 'run')
 

--- a/taskgroup/tasks.py
+++ b/taskgroup/tasks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import collections.abc
 import contextvars


### PR DESCRIPTION
I have been using taskgroup for Python versions 3.9 and 3.10, it works quite well.  I have run into one issue with the latest `0.0.0a4` release on PyPI, I get this error in some situations during cancel:
```
Traceback (most recent call last):
  ... snip ...
  File "/usr/lib/python3.9/asyncio/tasks.py", line 413, in wait
    return await _wait(fs, timeout, return_when, loop)
  File "/usr/lib/python3.9/asyncio/tasks.py", line 525, in _wait
    await waiter
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.9/unittest/async_case.py", line 64, in _callTestMethod
    self._callMaybeAsync(method)
  File "/usr/lib/python3.9/unittest/async_case.py", line 87, in _callMaybeAsync
    return self._asyncioTestLoop.run_until_complete(fut)
  File "/usr/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/usr/lib/python3.9/unittest/async_case.py", line 101, in _asyncioLoopRunner
    ret = await awaitable
  ... snip ...
  File "/home/dbn/usr/py-3.9/lib/python3.9/site-packages/taskgroup/taskgroups.py", line 71, in __aexit__
    if self._parent_cancel_requested and not self._parent_task.uncancel():
AttributeError: '_asyncio.Task' object has no attribute 'uncancel'
```

I noticed that HEAD has this fixed, to get it to work with Python 3.9 I just needed to switch some type annotations back to the Python 3.9 style, using `Union` and `Optional`.
