### PR TITLE
restore support for 3.8

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", pypy-3.10]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", pypy-3.10]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ a backport of asyncio.TaskGroup, asyncio.Runner and asyncio.timeout
 ## background
 
 This is a backport of the TaskGroup, Runner and timeout code from
-Python 3.12.8 to Python 3.9, Python 3.10 and Python 3.11.
+Python 3.12.8 to Python 3.8, Python 3.9, Python 3.10 and Python 3.11.
 
 ## operation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
 dependencies = ["exceptiongroup", "typing_extensions>=4.12.2,<5"]
 readme = "README.md"
+requires_python = ">=3.8"
 
 [project.urls]
 Home = "https://github.com/graingert/taskgroup"

--- a/taskgroup/install.py
+++ b/taskgroup/install.py
@@ -1,6 +1,6 @@
+import sys
 import contextvars
 import asyncio
-import collections.abc
 import contextlib
 import types
 from typing import cast
@@ -8,6 +8,11 @@ from typing import cast
 from .tasks import task_factory as _task_factory, Task as _Task
 
 from typing_extensions import Self, TypeVar
+
+if sys.version_info >= (3, 9):
+    from collections.abc import Generator, Coroutine
+else:
+    from typing import Generator, Coroutine
 
 
 UNCANCEL_DONE = object()
@@ -49,12 +54,12 @@ _ReturnT_co_nd = TypeVar("_ReturnT_co_nd", covariant=True)
 
 
 class WrapCoro(
-    collections.abc.Generator[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd],
-    collections.abc.Coroutine[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd],
+    Generator[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd],
+    Coroutine[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd],
 ):
     def __init__(
         self,
-        coro: collections.abc.Coroutine[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd],
+        coro: Coroutine[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd],
         context: contextvars.Context,
     ):
         self._coro = coro

--- a/taskgroup/runners.py
+++ b/taskgroup/runners.py
@@ -95,7 +95,7 @@ class Runner:
                 loop.run_until_complete(
                     loop.shutdown_default_executor(constants.THREAD_JOIN_TIMEOUT)  # type: ignore
                 )
-            else:
+            elif sys.version_info >= (3, 9):
                 loop.run_until_complete(loop.shutdown_default_executor())
         finally:
             if self._set_event_loop:

--- a/taskgroup/taskgroups.py
+++ b/taskgroup/taskgroups.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 __all__ = ["TaskGroup"]
 import sys
-import collections.abc
 from types import TracebackType
 from asyncio import events
 from asyncio import exceptions
@@ -24,6 +23,11 @@ from typing import Any, Union
 from typing_extensions import Self, TypeAlias, Literal, TypeVar
 import contextlib
 
+if sys.version_info >= (3, 9):
+    from collections.abc import Generator, Coroutine, Awaitable
+else:
+    from typing import Generator, Coroutine, Awaitable
+
 
 _T = TypeVar("_T")
 
@@ -35,15 +39,19 @@ _ReturnT_co_nd = TypeVar("_ReturnT_co_nd", covariant=True)
 
 _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
-_TaskYieldType: TypeAlias = Optional[futures.Future[object]]
+_TaskYieldType: TypeAlias = "futures.Future[object] | None"
 
 if sys.version_info >= (3, 12):
-    _TaskCompatibleCoro: TypeAlias = collections.abc.Coroutine[Any, Any, _T_co]
-else:
+    _TaskCompatibleCoro: TypeAlias = Coroutine[Any, Any, _T_co]
+elif sys.version_info >= (3, 9):
     _TaskCompatibleCoro: TypeAlias = Union[
-        collections.abc.Generator[_TaskYieldType, None, _T_co],
-        collections.abc.Coroutine[Any, Any, _T_co],
+        Generator[_TaskYieldType, None, _T_co],
+        Coroutine[Any, Any, _T_co],
     ]
+else:
+    _TaskCompatibleCoro: TypeAlias = (
+        "Generator[_TaskYieldType, None, _T_co] | Awaitable[_T_co]"
+    )
 
 
 class _TaskGroup:

--- a/taskgroup/tasks.py
+++ b/taskgroup/tasks.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-import collections.abc
 import contextvars
-from typing import Any, Optional, Union
+from typing import Any, Union, TYPE_CHECKING, Generic
 from typing_extensions import TypeAlias, TypeVar, Self
 import sys
+
+if sys.version_info >= (3, 9):
+    from collections.abc import Generator, Coroutine, Awaitable
+else:
+    from typing import Generator, Coroutine, Awaitable
 
 _YieldT_co = TypeVar("_YieldT_co", covariant=True)
 _SendT_contra = TypeVar("_SendT_contra", contravariant=True, default=None)
@@ -15,26 +19,30 @@ _ReturnT_co_nd = TypeVar("_ReturnT_co_nd", covariant=True)
 
 _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
-_TaskYieldType: TypeAlias = Optional[asyncio.Future[object]]
+_TaskYieldType: TypeAlias = "asyncio.Future[object] | None"
 
 if sys.version_info >= (3, 12):
-    _TaskCompatibleCoro: TypeAlias = collections.abc.Coroutine[Any, Any, _T_co]
-else:
+    _TaskCompatibleCoro: TypeAlias = Coroutine[Any, Any, _T_co]
+elif sys.version_info >= (3, 9):
     _TaskCompatibleCoro: TypeAlias = Union[
-        collections.abc.Generator[_TaskYieldType, None, _T_co],
-        collections.abc.Coroutine[Any, Any, _T_co],
+        Generator[_TaskYieldType, None, _T_co],
+        Coroutine[Any, Any, _T_co],
     ]
+else:
+    _TaskCompatibleCoro: TypeAlias = (
+        "Generator[_TaskYieldType, None, _T_co] | Awaitable[_T_co]"
+    )
 
 
 class _Interceptor(
-    collections.abc.Generator[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd],
-    collections.abc.Coroutine[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd],
+    Generator[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd],
+    Coroutine[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd],
 ):
     def __init__(
         self,
         coro: (
-            collections.abc.Coroutine[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd]
-            | collections.abc.Generator[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd]
+            Coroutine[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd]
+            | Generator[_YieldT_co, _SendT_contra_nd, _ReturnT_co_nd]
         ),
         context: contextvars.Context,
     ):
@@ -57,7 +65,21 @@ class _Interceptor(
         super().close()
 
 
-class Task(asyncio.Task[_T_co]):
+if TYPE_CHECKING:
+
+    class _Task(asyncio.Task[_T_co]):
+        pass
+
+
+elif sys.version_info >= (3, 9):
+    _Task = asyncio.Task
+else:
+
+    class _Task(asyncio.Task, Generic[_T_co]):
+        pass
+
+
+class Task(_Task[_T_co]):
     def __init__(
         self, coro: _TaskCompatibleCoro[_T_co], *args, context=None, **kwargs
     ) -> None:


### PR DESCRIPTION
fixes #29

I accidentally forgot to set requires_python, so we need a 3.8 support release which is then reverted